### PR TITLE
feat: add personal best tracking per test mode

### DIFF
--- a/components/results-screen.tsx
+++ b/components/results-screen.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useEffect, useRef, useState, type ReactNode } from "react";
 import { Confetti, type ConfettiRef } from "@/components/ui/confetti";
 import { isInvalidTestResult } from "@/lib/validate-result";
+import { saveIfPersonalBest } from "@/lib/personal-best";
 import { motion } from "motion/react";
 import { IconInfoCircle, IconRefresh, IconArrowRight, IconDownload } from "@tabler/icons-react";
 import {
@@ -213,6 +214,12 @@ export function ResultsScreen({ stats, onRestart, onNext }: ResultsScreenProps) 
   const confettiRef = useRef<ConfettiRef>(null)
   const invalid = isInvalidTestResult(stats)
 
+  const pb = useMemo(
+    () => invalid ? null : saveIfPersonalBest(mode, modeDetail, wpm, accuracy),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
+
   useEffect(() => {
     if (!invalid && wpm >= 100) {
       const timer = setTimeout(() => {
@@ -286,6 +293,16 @@ export function ResultsScreen({ stats, onRestart, onNext }: ResultsScreenProps) 
         <div className="flex w-full flex-col gap-1 pt-2 md:w-36 md:shrink-0">
           <StatBig label="wpm" value={wpm} />
           <StatBig label="acc" value={`${accuracy}%`} />
+          {pb?.isNewPb && (
+            <span className="text-xs font-medium text-primary animate-in fade-in">
+              new personal best
+            </span>
+          )}
+          {pb && !pb.isNewPb && pb.previous && (
+            <span className="text-[10px] text-muted-foreground">
+              pb: {pb.previous.wpm} wpm
+            </span>
+          )}
           <div className="mt-4 flex flex-col gap-0.5 text-xs text-muted-foreground">
             <span className="text-[10px] uppercase tracking-widest opacity-50">
               test type

--- a/lib/personal-best.ts
+++ b/lib/personal-best.ts
@@ -1,0 +1,40 @@
+// Key format: "kz-pb-{mode}-{detail}" e.g. "kz-pb-time-30", "kz-pb-quote-medium"
+const PB_PREFIX = "kz-pb-";
+
+export interface PersonalBest {
+  wpm: number;
+  accuracy: number;
+  date: string;
+}
+
+function pbKey(mode: string, detail: string): string {
+  return `${PB_PREFIX}${mode}-${detail}`;
+}
+
+export function getPersonalBest(mode: string, detail: string): PersonalBest | null {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(pbKey(mode, detail));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PersonalBest;
+  } catch {
+    return null;
+  }
+}
+
+export function saveIfPersonalBest(
+  mode: string,
+  detail: string,
+  wpm: number,
+  accuracy: number,
+): { isNewPb: boolean; previous: PersonalBest | null } {
+  const prev = getPersonalBest(mode, detail);
+  if (!prev || wpm > prev.wpm) {
+    localStorage.setItem(
+      pbKey(mode, detail),
+      JSON.stringify({ wpm, accuracy, date: new Date().toISOString() }),
+    );
+    return { isNewPb: true, previous: prev };
+  }
+  return { isNewPb: false, previous: prev };
+}


### PR DESCRIPTION

<img width="1237" height="708" alt="image" src="https://github.com/user-attachments/assets/4994d7b3-a6ea-4113-b77f-fe17ac91bad7" />


Adds personal best (PB) tracking per test mode using localStorage. After each valid test, the result is compared against the stored PB for that mode and configuration. The results screen now shows either a "new personal best" label or the previous PB wpm for reference.

Users have no way to track their progress across sessions. This is the most commonly requested feature in typing test apps and requires zero backend infrastructure.

Each personal best is stored as a separate localStorage entry. The key format is `kz-pb-{mode}-{detail}`, where mode is the test type (`time`, `words`, `quote`, `zen`) and detail is the configuration value (`30`, `25`, `medium`, etc.). This means each mode and configuration tracks its own PB independently.


**Value structure:**
```json
{ "wpm": 87, "accuracy": 96, "date": "2026-04-13T14:10:00.000Z" }
