### PR TITLE
fix: replace useMemo with lazy useState for personal best save

### DIFF
--- a/components/results-screen.tsx
+++ b/components/results-screen.tsx
@@ -214,11 +214,7 @@ export function ResultsScreen({ stats, onRestart, onNext }: ResultsScreenProps) 
   const confettiRef = useRef<ConfettiRef>(null)
   const invalid = isInvalidTestResult(stats)
 
-  const pb = useMemo(
-    () => invalid ? null : saveIfPersonalBest(mode, modeDetail, wpm, accuracy),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  )
+  const [pb] = useState(() => invalid ? null : saveIfPersonalBest(mode, modeDetail, wpm, accuracy));
 
   useEffect(() => {
     if (!invalid && wpm >= 100) {


### PR DESCRIPTION
`useMemo` was being used to trigger a `localStorage.setItem()` side effect. React docs explicitly state that `useMemo` may discard its cache and re-execute at any time (Strict Mode, React Compiler, future versions).

This replaces the hack with a `useState` lazy initializer. React guarantees the initializer function runs exactly once during mount. This achieves side-effect safety, prevents unexpected re-executions, and cleanly passes ESLint rules.

### Why

* **Side Effect Safety:** `useMemo` is not meant for side effects like `localStorage.setItem()`. React may discard `useMemo` caches and re-run them anytime, causing duplicate writes.
* **Guaranteed Run-Once:** The lazy `useState(() => ...)` pattern is structurally guaranteed by React to execute its initializer function exactly once on initial render.
* **Removes Hacks:** Eliminates the `// eslint-disable-next-line` comment that was required to bypass the linter on the previous `useMemo` array.
