### PR TITLE
 Fix syntax highlighting misbehaving on language/chapter switch

### DIFF
--- a/hooks/use-shiki.ts
+++ b/hooks/use-shiki.ts
@@ -57,7 +57,11 @@ export function useShikiTokens(
     }
 
     const codeToHighlight = rawCode ?? words.join("\n");
-    const key = `${lang}:${theme}:${codeToHighlight}`;
+    // Include a words fingerprint so the effect re-runs when words update
+    // after a language/chapter switch (words lag behind rawCode by ~150 ms
+    // due to the reset animation delay, causing colour misalignment).
+    const wordsKey = words.join("|");
+    const key = `${lang}:${theme}:${codeToHighlight}:${wordsKey}`;
     if (key === prevKey.current) return;
     prevKey.current = key;
 
@@ -120,6 +124,9 @@ export function useShikiTokens(
     })();
 
     return () => { cancelled = true; };
+  // `words` must be in the dep array (not just rawCode) so that when the
+  // word list updates after the animation delay, the effect fires and
+  // re-maps colours to the now-correct word positions.
   }, [words, lang, enabled, theme, rawCode]);
 
   return colorMap;

--- a/hooks/use-shiki.ts
+++ b/hooks/use-shiki.ts
@@ -57,9 +57,6 @@ export function useShikiTokens(
     }
 
     const codeToHighlight = rawCode ?? words.join("\n");
-    // Include a words fingerprint so the effect re-runs when words update
-    // after a language/chapter switch (words lag behind rawCode by ~150 ms
-    // due to the reset animation delay, causing colour misalignment).
     const wordsKey = words.join("|");
     const key = `${lang}:${theme}:${codeToHighlight}:${wordsKey}`;
     if (key === prevKey.current) return;
@@ -124,9 +121,6 @@ export function useShikiTokens(
     })();
 
     return () => { cancelled = true; };
-  // `words` must be in the dep array (not just rawCode) so that when the
-  // word list updates after the animation delay, the effect fires and
-  // re-maps colours to the now-correct word positions.
   }, [words, lang, enabled, theme, rawCode]);
 
   return colorMap;


### PR DESCRIPTION
When switching languages or chapters in code mode, syntax highlighting would partially disappear or show wrong colors, then come back correct after a full page refresh.

https://github.com/user-attachments/assets/2824ed59-7704-4de1-804b-b544fdd3f461


### What was happening

`rawCode` updates immediately when a new language/chapter is selected, but `words` lags ~150ms behind because of the reset animation delay in `resetTestWith`. The Shiki effect would fire with the new `rawCode` but the old `words`, mapping token colors to wrong word positions.

When `words` finally updated, the effect's cache key,  which was only `lang:theme:rawCode` , hadn't changed, so the effect was skipped and the broken color map was never corrected.

### Fix

Added a `words` fingerprint to the cache key so the effect always re-runs when the word list changes, regardless of whether `rawCode` changed.