### PR TITLE
feat: load random chapter on refresh in code mode

### DIFF
--- a/components/typing-test.tsx
+++ b/components/typing-test.tsx
@@ -555,7 +555,7 @@ function RestartButton({
         "rounded-lg p-2 text-muted-foreground transition-colors hover:text-foreground",
         !controlsVisible && "pointer-events-none"
       )}
-      title="Restart test"
+      title="Random chapter"
     >
       <span
         style={{

--- a/hooks/use-typing-test.ts
+++ b/hooks/use-typing-test.ts
@@ -973,6 +973,12 @@ const onCodeLanguageChange = useCallback((next: string) => {
     onModeChange, onTimeOptionChange, onWordOptionChange, onQuoteLengthChange,
     onPunctuationToggle, onNumbersToggle, onDifficultyToggle,
     onCustomTextChange, onCodeLanguageChange, onCodeChapterChange,
-    onRestart: () => resetTest(),
+    onRestart: () => {
+      if (mode !== "code") return resetTest();
+      const others = (CODE_MANIFEST[codeLanguage]?.chapters ?? []).filter(c => c !== codeChapter);
+      const pick = others[Math.floor(Math.random() * others.length)];
+      if (pick) { setCodeChapter(pick); localStorage.setItem(CODE_CHAPTER_STORAGE_KEY, pick); }
+      resetTest(pick ? { codeChapter: pick } : {});
+    },
   };
 }


### PR DESCRIPTION
The refresh icon and `Tab+Enter` were both doing the same thing in
code mode — restarting the same chapter.
This PR gives the refresh icon a distinct purpose: it now loads a
**random chapter** from the current language, just like every other
mode loads new words on refresh.
`Tab+Enter` still restarts the **same** chapter (good for deliberate practice).
## Changes
- `hooks/use-typing-test.ts` — `onRestart` picks a random chapter in code mode 
- `components/typing-test.tsx` — updated button tooltip to reflect new behaviour
## Edge case
If a language has only one chapter, it falls back to restarting that same chapter.